### PR TITLE
[TASK] Support --failsafe command line option

### DIFF
--- a/typo3
+++ b/typo3
@@ -17,8 +17,8 @@
  * Command Line Interface module dispatcher
  * that executes commands
  */
-call_user_func(function() {
+call_user_func(function() use ($argv) {
     $classLoader = require __DIR__ . '/../../autoload.php';
     \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(1, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI);
-    \TYPO3\CMS\Core\Core\Bootstrap::init($classLoader)->get(\TYPO3\CMS\Core\Console\CommandApplication::class)->run();
+    \TYPO3\CMS\Core\Core\Bootstrap::init($classLoader, in_array('--failsafe', $argv))->get(\TYPO3\CMS\Core\Console\CommandApplication::class)->run();
 });


### PR DESCRIPTION
This change is the complement to the TYPO3 core
changes as provided in https://review.typo3.org/c/58264/

This is not a breaking change. A minor or patch release
is sufficient.