### PR TITLE
[!!!][TASK] Adapt to command handling in TYPO3 v11.1

### DIFF
--- a/typo3
+++ b/typo3
@@ -20,5 +20,5 @@
 call_user_func(function() {
     $classLoader = require __DIR__ . '/../../autoload.php';
     \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(1, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI);
-    \TYPO3\CMS\Core\Core\Bootstrap::init($classLoader)->get(\TYPO3\CMS\Core\Console\CommandApplication::class)->run();
+    \TYPO3\CMS\Core\Core\Bootstrap::init($classLoader, true)->get(\TYPO3\CMS\Core\Console\CommandApplication::class)->run();
 });


### PR DESCRIPTION
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/67241
the console application is booted in "failsafe" mode,
in order to support low level commands.
This change is backwards incompatible, and requires
TYPO3 version as of `11.1`.

To be released as `3.0.0`, once the core patch is agreed on in Gerrit (therefore WIP for now) 
 TYPO3 core will depend on `typo3/cms-cli:^3.0` to ensure only TYPO3 `>= 11.1` is using this version of `typo3/cms-cli`.

Issue on forge:
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/67241

