### PR TITLE
[BUGFIX] Use correct autoload path, in case this package is linked

### DIFF
--- a/typo3
+++ b/typo3
@@ -18,7 +18,7 @@
  * that executes commands
  */
 call_user_func(function() {
-    $classLoader = require __DIR__ . '/../../autoload.php';
+    $classLoader = require ($GLOBALS['_composer_autoload_path'] ?? __DIR__ . '/../../autoload.php');
     \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(1, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI);
     \TYPO3\CMS\Core\Core\Bootstrap::init($classLoader, true)->get(\TYPO3\CMS\Core\Console\CommandApplication::class)->run();
 });


### PR DESCRIPTION
In current Composer versions, the binaries are not links any more
but files to allow the packages to be linked (e.g. from path repository).
For that Composer populates $GLOBALS['_composer_autoload_path']
in the created binary file to expose the correct path to the autoload
file for this installation.

So we should use this path if a current Composer version is used
and can gracefully fall back to directory traversal for older versions.