### PR TITLE
[TASK] Temporarily workaround a missing conflict in symfony/type-info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,11 @@
 	"description": "TYPO3 command line binary",
 	"homepage": "https://typo3.org",
 	"license": ["GPL-2.0-or-later"],
-
 	"require": {
 		"php" : "^7.0 || ^8.0"
+	},
+	"conflict": {
+		"phpstan/phpdoc-parser": "<1.0 || >=2.0"
 	},
 	"bin": [
 		"typo3"


### PR DESCRIPTION
`symfony/type-info` is currently not compatible to `phpstan/phpdoc-parser` 2.x which results in a PHP error in extbase modules as shown in https://forge.typo3.org/issues/105582. A fix has been merged upstream, but has not been released yet and it seems there will be no immediate hotfix release by symfony – that means it will only be released by the end of the month [2]).

Explanation of the issue:

`phpdocumentor/reflection-docblock` 5.6.0 [1] was released yesterday which allows `composer install` and `composer update` to raise `phpstan/phpdoc-parser` to 2.x.

Since symfony/type-info has an optional dependency to `phpstan/phpdoc-parser`, a conflict is used to express the supported version. This upstream conflict has a weak range [3] as it only forbids incompatible old versions, but not new upcoming *major*(!) versions.
The statement `"conflict": "<1.0"`[3] forbids to install any version before 1.0, but missed to opt out from future major releases (which are allowed to be breaking per semver).

Now that `phpstan/phpdoc-parser` 2.x has been released and is allowed to be installed by other dependencies like
`phpdocumentor/reflection-docblock` (which is perfectly fine), this range flaw got revealed.

This workaround will be removed once `symfony/type-info` has been updated to allow an upgrade to `phpstan/phpdoc-parser`. For that reason this conflict is only added to this composer-only package to avoid a comlete TYPO3 release and is not added to extbase (extbase is not incompatible, `symfony/type-info` is).

[1] https://github.com/phpDocumentor/ReflectionDocBlock/releases/tag/5.6.0
[2] https://github.com/symfony/symfony/pull/58800#issuecomment-2471013822
[3] https://github.com/symfony/type-info/blob/v7.1.6/composer.json#L36-L37
[4] https://github.com/symfony/symfony/pull/58800#issuecomment-2470646929