### PR TITLE
[TASK] Align phpstan/phpdoc-parser conflict with Symfony type-info constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,6 @@
 	"require": {
 		"php" : "^7.0 || ^8.0"
 	},
-	"conflict": {
-        "phpstan/phpdoc-parser": "<1.30"
-	},
 	"bin": [
 		"typo3"
 	]

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php" : "^7.0 || ^8.0"
 	},
 	"conflict": {
-		"phpstan/phpdoc-parser": "<1.0 || >=2.0"
+        "phpstan/phpdoc-parser": "<1.30"
 	},
 	"bin": [
 		"typo3"


### PR DESCRIPTION
## Summary  
This pull request updates the `composer.json` of the `typo3/cms-cli` package to align the `phpstan/phpdoc-parser` conflict constraint with what is used by `symfony/type-info`.

- **Before**: `"phpstan/phpdoc-parser": "<1.0 || >=2.0"`  
- **After**:  `"phpstan/phpdoc-parser": "<1.30"`

## Reason  
The broad upper bound (`>=2.0`) was introduced as a workaround for a compatibility issue in an earlier version ([see PR #9](https://github.com/TYPO3/cms-cli/pull/9)). Since that issue has been addressed upstream, this workaround is no longer necessary.

Aligning the constraint removes the blocker for tools requiring `phpstan/phpdoc-parser ^2.x`.

## Impact
- Projects using `cms-cli` can now move to `phpstan/phpdoc-parser ^2.x` when required.
- Compatibility with `phpstan/phpdoc-parser >=1.30` remains unaffected.